### PR TITLE
slides: add js-prefix to lesson 6 slides

### DIFF
--- a/lessons/6_objects_intro/index.html
+++ b/lessons/6_objects_intro/index.html
@@ -132,7 +132,8 @@ document.querySelector(".js-book-price").innerText = price;
 document.querySelector(".js-book-pages").innerText = pageCount;
           </code></pre>
                 <br>
-                <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector" target="_blank">querySelector info</a>
+                <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector" target="_blank">querySelector
+                    info</a>
             </div>
             <div class="fragment">
             </div>
@@ -181,16 +182,23 @@ document.querySelector(".js-book-pages").innerText = pageCount;
                 <li class="fragment">The value is like a variable itself</li>
             </ul>
             <br/>
-            <div>
-                            <pre><code>
-              let book = {
-                title: "Raising goats for dummies",
-                image: "goats.jpg",
-                pageCount: 340,
-                price: 15
-              };
-        </code></pre>
-            </div>
+
+            <pre><code>
+  const goatBook = {
+    title: "Raising goats for dummies",
+    image: "goats.jpg",
+    pageCount: 340,
+    price: 15
+  };
+
+  const zombRacBook = {
+    title: "Zombie Raccoons & Killer Bunnies",
+    image: "zombie_raccoons.jpg",
+    pageCount: 643,
+    price: 20
+  };
+                </code>
+                    </pre>
         </section>
         <section>
             <h2>What can we do with objects?</h2>
@@ -198,47 +206,44 @@ document.querySelector(".js-book-pages").innerText = pageCount;
         <section>
             <h3>Get value of it's attributes</h3>
             <pre><code data-trim>
-              let book = {
+              let goatBook = {
                 title: "Raising goats for dummies",
                 image: "goats.jpg",
                 pageCount: 340,
                 price: 15
               };
 
-          alert("Book name is " + book.title);
+          alert("Book name is " + goatBook.title);
             </code></pre>
         </section>
         <section>
             <h3>Change value of it's attributes</h3>
             <pre><code data-trim>
-              let book = {
+              let goatBook = {
                 title: "Raising goats for dummies",
                 image: "goats.jpg",
                 pageCount: 340,
                 price: 15
               };
-
-              alert(book.title + " has " + book.pageCount + " pages");
-
-              book.pageCount = 900;
-
-              alert(book.title + " has " + book.pageCount + " pages");
+              let newPageCount =  prompt("There are " + goatBook.pageCount + " pages now, enter new page count value");
+              goatBook.pageCount = newPageCount;
+              alert(goatBook.title + " has " + goatBook.pageCount + " pages");
             </code></pre>
         </section>
 
         <section>
             <h3>And even add new attributes</h3>
             <pre><code data-trim>
-              let book = {
+              let goatBook = {
                 title: "Raising goats for dummies",
                 image: "goats.jpg",
                 pageCount: 340,
                 price: 15
               };
 
-              book.rating = "5 stars";
+              goatBook.rating = "5 stars";
 
-              alert(book.title + " book was rated with " + book.rating);
+              alert(goatBook.title + " goatBook was rated with " + goatBook.rating);
             </code></pre>
         </section>
 
@@ -279,86 +284,6 @@ console.log(strangeButtonCmp.classList);
               alert(person.name + "'s favorite book is " + person.favoriteBook.name);
             </code></pre>
             </div>
-        </section>
-
-        <section>
-            <h3>Book Example</h3>
-            <div class="js-book-list"></div>
-            <script>
-              const goatBook = {
-                title: "Raising goats for dummies",
-                image: "goats.jpg",
-                pageCount: 340,
-                price: 15
-              };
-
-              const zombRacBook = {
-                title: "Zombie Raccoons & Killer Bunnies",
-                image: "zombie_raccoons.jpg",
-                pageCount: 643,
-                price: 20
-              };
-
-
-              const bookListEl = document.querySelector(".js-book-list");
-              function renderBook(book) {
-                const bookEl = document.createElement('div');
-                bookEl.innerHTML = `
-                    <div class="book">
-                        <img src="${book.image}">
-                        <div>
-                            <div>Title: ${book.title}</div>
-                            <div>Price: ${book.price} &euro;</div>
-                            <div>Length: ${book.pageCount} pages</div>
-                        </div>
-                    </div>
-                `;
-                bookListEl.appendChild(bookEl);
-              }
-
-              renderBook(goatBook);
-              renderBook(zombRacBook);
-            </script>
-        </section>
-
-        <section>
-            <h3>Book Example</h3>
-            <div class="js-book-list"></div>
-            <pre><code>
-  const goatBook = {
-    title: "Raising goats for dummies",
-    image: "goats.jpg",
-    pageCount: 340,
-    price: 15
-  };
-
-  const zombRacBook = {
-    title: "Zombie Raccoons & Killer Bunnies",
-    image: "zombie_raccoons.jpg",
-    pageCount: 643,
-    price: 20
-  };
-
-  const bookListEl = document.querySelector(".js-book-list");
-
-  function renderBook(book) {
-    const bookEl = document.createElement('div');
-    bookEl.innerHTML = `
-        <div class="book">
-            <img src="${book.image}">
-            <div>
-                <div>Title: ${book.title}</div>
-                <div>Price: ${book.price} &euro;</div>
-                <div>Length: ${book.pageCount} pages</div>
-            </div>
-        </div>
-    `;
-    bookListEl.appendChild(bookEl);
-  }
-
-  renderBook(goatBook);
-  renderBook(zombRacBook);
-            </pre></code>
         </section>
 
         <section>

--- a/lessons/6_objects_intro/index.html
+++ b/lessons/6_objects_intro/index.html
@@ -70,6 +70,7 @@
         .book-sample-img img {
             max-height: 40vh;;
         }
+
     </style>
 </head>
 
@@ -145,9 +146,12 @@ document.querySelector(".js-book-pages").innerText = pageCount;
                     <img src="goats.jpg">
                     <img src="zombie_raccoons.jpg">
                 </div>
-                <br>
-                <div class="fragment">
-                    <pre><code data-trim>
+            </div>
+        </section>
+
+        <section>
+            <h3>Time to add a second book!</h3>
+            <pre><code data-trim>
             let title1 = "Raising goats for dummies";
             let image1 = "goats.jpg";
             let pageCount1 = 340;
@@ -157,10 +161,7 @@ document.querySelector(".js-book-pages").innerText = pageCount;
             let image2 = "zombie_raccoons.jpg";
             let pageCount2 = 643;
             let price2 = 20;
-          </code></pre>
-
-                </div>
-            </div>
+            </code></pre>
         </section>
 
         <section class="">
@@ -170,25 +171,6 @@ document.querySelector(".js-book-pages").innerText = pageCount;
 
         <section>
             <h3>OBJECTS TO THE RESCUE!!</h3>
-            <div class="fragment">
-            <pre><code data-trim>
-              let book = {
-                title: "Raising goats for dummies",
-                image: "goats.jpg",
-                pageCount: 340,
-                price: 15
-              };
-            </code></pre>
-            </div>
-            <br/>
-            <div class="fragment">
-            <pre><code data-trim>
-document.querySelector(".js-book-img").src = book.image;
-document.querySelector(".js-book-name").innerText = book.name;
-document.querySelector(".js-book-price").innerText = book.price;
-document.querySelector(".js-book-pages").innerText = book.pageCount;
-            </code></pre>
-            </div>
         </section>
 
         <section>
@@ -297,6 +279,86 @@ console.log(strangeButtonCmp.classList);
               alert(person.name + "'s favorite book is " + person.favoriteBook.name);
             </code></pre>
             </div>
+        </section>
+
+        <section>
+            <h3>Book Example</h3>
+            <div class="js-book-list"></div>
+            <script>
+              const goatBook = {
+                title: "Raising goats for dummies",
+                image: "goats.jpg",
+                pageCount: 340,
+                price: 15
+              };
+
+              const zombRacBook = {
+                title: "Zombie Raccoons & Killer Bunnies",
+                image: "zombie_raccoons.jpg",
+                pageCount: 643,
+                price: 20
+              };
+
+
+              const bookListEl = document.querySelector(".js-book-list");
+              function renderBook(book) {
+                const bookEl = document.createElement('div');
+                bookEl.innerHTML = `
+                    <div class="book">
+                        <img src="${book.image}">
+                        <div>
+                            <div>Title: ${book.title}</div>
+                            <div>Price: ${book.price} &euro;</div>
+                            <div>Length: ${book.pageCount} pages</div>
+                        </div>
+                    </div>
+                `;
+                bookListEl.appendChild(bookEl);
+              }
+
+              renderBook(goatBook);
+              renderBook(zombRacBook);
+            </script>
+        </section>
+
+        <section>
+            <h3>Book Example</h3>
+            <div class="js-book-list"></div>
+            <pre><code>
+  const goatBook = {
+    title: "Raising goats for dummies",
+    image: "goats.jpg",
+    pageCount: 340,
+    price: 15
+  };
+
+  const zombRacBook = {
+    title: "Zombie Raccoons & Killer Bunnies",
+    image: "zombie_raccoons.jpg",
+    pageCount: 643,
+    price: 20
+  };
+
+  const bookListEl = document.querySelector(".js-book-list");
+
+  function renderBook(book) {
+    const bookEl = document.createElement('div');
+    bookEl.innerHTML = `
+        <div class="book">
+            <img src="${book.image}">
+            <div>
+                <div>Title: ${book.title}</div>
+                <div>Price: ${book.price} &euro;</div>
+                <div>Length: ${book.pageCount} pages</div>
+            </div>
+        </div>
+    `;
+    bookListEl.appendChild(bookEl);
+  }
+
+  renderBook(goatBook);
+  renderBook(zombRacBook);
+            </pre></code>
         </section>
 
         <section>

--- a/lessons/6_objects_intro/index.html
+++ b/lessons/6_objects_intro/index.html
@@ -103,11 +103,11 @@
             <pre>
 					<code data-trim>
               <div class="book">
-                    <img src="goats.jpg">
+                    <img class="js-book-img" src="goats.jpg">
                     <div>
-                        <div>Name: <span>Raising goats for dummies</span></div>
-                        <div>Price: <span class="price">15 &euro;</span></div>
-                        <div>Length: <span class="pages">340 pages</span></div>
+                        <div>Name: <span class="js-book-name">Raising goats for dummies</span></div>
+                        <div>Price: <span class="price js-book-price">15 &euro;</span></div>
+                        <div>Length: <span class="pages js-book-pages">340 pages</span></div>
                     </div>
                 </div>
                 	</code>
@@ -115,7 +115,7 @@
             </div>
         </section>
 
-        <section class="">
+        <section>
             <h3>But all this information can come from elsewhere</h3>
             <p class="fragment">Lest not hard-code it in HTML</p>
             <div class="fragment">
@@ -125,10 +125,10 @@ let image = "goats.jpg";
 let pageCount = 340;
 let price = 15;
 
-document.querySelector(".book img").src = image;
-document.querySelector(".book.name").innerText = name;
-document.querySelector(".book.price").innerText = price;
-document.querySelector(".book.pages").innerText = pageCount;
+document.querySelector(".js-book-img").src = image;
+document.querySelector(".js-book-name").innerText = name;
+document.querySelector(".js-book-price").innerText = price;
+document.querySelector(".js-book-pages").innerText = pageCount;
           </code></pre>
                 <br>
                 <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector" target="_blank">querySelector info</a>
@@ -183,10 +183,10 @@ document.querySelector(".book.pages").innerText = pageCount;
             <br/>
             <div class="fragment">
             <pre><code data-trim>
-document.querySelector(".book img").src = book.image;
-document.querySelector(".book.name").innerText = book.name;
-document.querySelector(".book.price").innerText = book.price;
-document.querySelector(".book.pages").innerText = book.pageCount;
+document.querySelector(".js-book-img").src = book.image;
+document.querySelector(".js-book-name").innerText = book.name;
+document.querySelector(".js-book-price").innerText = book.price;
+document.querySelector(".js-book-pages").innerText = book.pageCount;
             </code></pre>
             </div>
         </section>
@@ -235,6 +235,8 @@ document.querySelector(".book.pages").innerText = book.pageCount;
                 pageCount: 340,
                 price: 15
               };
+
+              alert(book.title + " has " + book.pageCount + " pages");
 
               book.pageCount = 900;
 


### PR DESCRIPTION
Few small changes like adding `js` prefix to classes being selected form js.. mentioned in #16 

Also I didn't really get what the objects were giving us in the book example. To me was not clear the added benefit. I created an additional slide with an example of a function that renders a book object. Trying to show why books objects could be useful. 